### PR TITLE
Add System.Text.Json log event formatter

### DIFF
--- a/Serilog.Sinks.Scalyr.Tests/Exception.fs
+++ b/Serilog.Sinks.Scalyr.Tests/Exception.fs
@@ -16,10 +16,10 @@ let tests =
 
   testApi.Continue.WaitOne(1000) |> ignore
 
-  let actual = testApi.Received.[0] |> getFirstEvent |> getAttrs |> getObject "Exception"
+  let actual = testApi.NewtonsoftReceived.[0] |> getFirstJEvent |> getJAttrs |> getObject "Exception"
 
   let expected = exn "BOOM" |> JObject.FromObject
 
   test "Exception is set" {
-    Expect.isTrue (JToken.DeepEquals(actual, expected)) (sprintf "%O : %O" actual expected)
+    Expect.isTrue (JToken.DeepEquals(actual, expected)) $"{actual} : {expected}"
   }

--- a/Serilog.Sinks.Scalyr.Tests/Exception.fs
+++ b/Serilog.Sinks.Scalyr.Tests/Exception.fs
@@ -16,7 +16,7 @@ let tests =
 
   testApi.Continue.WaitOne(1000) |> ignore
 
-  let actual = testApi.NewtonsoftReceived.[0] |> getFirstJEvent |> getJAttrs |> getObject "Exception"
+  let actual = testApi.NewtonsoftReceived.[0] |> getFirstEvent |> getAttrs |> getObject "Exception"
 
   let expected = exn "BOOM" |> JObject.FromObject
 

--- a/Serilog.Sinks.Scalyr.Tests/Helpers.fs
+++ b/Serilog.Sinks.Scalyr.Tests/Helpers.fs
@@ -1,42 +1,12 @@
 [<AutoOpen>]
 module Helpers
 
-open System.IO
-open System.Text
-open System.Text.Encodings.Web
-open System.Text.Json
-open System.Text.Unicode
 open Newtonsoft.Json.Linq
 
-let getObject (name: string) (jObject: JObject) : JToken = jObject.[name]
+let getObject name (jObject : JObject) = jObject.[name]
 
-let getJValue (name: string) (jObject: JObject) : string = jObject.[name].Value<string>()
+let getValue name (jObject : JObject) = jObject.[name].Value<string>()
 
-let getFirstJEvent (jObject: JObject) : JObject =
-    jObject.["events"].Value<JArray>().[0].ToObject()
+let getFirstEvent (jObject : JObject) = jObject.["events"].Value<JArray>().[0].ToObject()
 
-let getJAttrs (jObject: JObject) : JObject = jObject.["attrs"].ToObject()
-
-
-let getProperty (name: string) (element: JsonElement) : JsonElement = element.GetProperty(name)
-
-let getValue (name: string) (element: JsonElement) : string = element.GetProperty(name).GetString()
-
-let getFirstEvent (element: JsonElement) : JsonElement =
-    element.GetProperty("events").EnumerateArray()
-    |> Seq.head
-
-let getAttrs (element: JsonElement) : JsonElement = element.GetProperty("attrs")
-
-let indentedWriterOptions =
-    JsonWriterOptions(Indented = true, Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping)
-    
-let serializeDocumentIndented (doc: JsonDocument) : string =
-    use stream = new MemoryStream()
-    using (new Utf8JsonWriter(stream, indentedWriterOptions)) doc.WriteTo
-    Encoding.UTF8.GetString(stream.ToArray())
-
-let serializeElementIndented (element: JsonElement) : string =
-    use stream = new MemoryStream()
-    using (new Utf8JsonWriter(stream, indentedWriterOptions)) element.WriteTo
-    Encoding.UTF8.GetString(stream.ToArray())
+let getAttrs (jObject : JObject) = jObject.["attrs"].ToObject()

--- a/Serilog.Sinks.Scalyr.Tests/Helpers.fs
+++ b/Serilog.Sinks.Scalyr.Tests/Helpers.fs
@@ -1,12 +1,42 @@
 [<AutoOpen>]
 module Helpers
 
+open System.IO
+open System.Text
+open System.Text.Encodings.Web
+open System.Text.Json
+open System.Text.Unicode
 open Newtonsoft.Json.Linq
 
-let getObject name (jObject : JObject) = jObject.[name]
+let getObject (name: string) (jObject: JObject) : JToken = jObject.[name]
 
-let getValue name (jObject : JObject) = jObject.[name].Value<string>()
+let getJValue (name: string) (jObject: JObject) : string = jObject.[name].Value<string>()
 
-let getFirstEvent (jObject : JObject) = jObject.["events"].Value<JArray>().[0].ToObject()
+let getFirstJEvent (jObject: JObject) : JObject =
+    jObject.["events"].Value<JArray>().[0].ToObject()
 
-let getAttrs (jObject : JObject) = jObject.["attrs"].ToObject()
+let getJAttrs (jObject: JObject) : JObject = jObject.["attrs"].ToObject()
+
+
+let getProperty (name: string) (element: JsonElement) : JsonElement = element.GetProperty(name)
+
+let getValue (name: string) (element: JsonElement) : string = element.GetProperty(name).GetString()
+
+let getFirstEvent (element: JsonElement) : JsonElement =
+    element.GetProperty("events").EnumerateArray()
+    |> Seq.head
+
+let getAttrs (element: JsonElement) : JsonElement = element.GetProperty("attrs")
+
+let indentedWriterOptions =
+    JsonWriterOptions(Indented = true, Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping)
+    
+let serializeDocumentIndented (doc: JsonDocument) : string =
+    use stream = new MemoryStream()
+    using (new Utf8JsonWriter(stream, indentedWriterOptions)) doc.WriteTo
+    Encoding.UTF8.GetString(stream.ToArray())
+
+let serializeElementIndented (element: JsonElement) : string =
+    use stream = new MemoryStream()
+    using (new Utf8JsonWriter(stream, indentedWriterOptions)) element.WriteTo
+    Encoding.UTF8.GetString(stream.ToArray())

--- a/Serilog.Sinks.Scalyr.Tests/Helpers.fs
+++ b/Serilog.Sinks.Scalyr.Tests/Helpers.fs
@@ -3,10 +3,11 @@ module Helpers
 
 open Newtonsoft.Json.Linq
 
-let getObject name (jObject : JObject) = jObject.[name]
+let getObject name (jObject: JObject) = jObject.[name]
 
-let getValue name (jObject : JObject) = jObject.[name].Value<string>()
+let getValue name (jObject: JObject) = jObject.[name].Value<string>()
 
-let getFirstEvent (jObject : JObject) = jObject.["events"].Value<JArray>().[0].ToObject()
+let getFirstEvent (jObject: JObject) =
+    jObject.["events"].Value<JArray>().[0].ToObject()
 
-let getAttrs (jObject : JObject) = jObject.["attrs"].ToObject()
+let getAttrs (jObject: JObject) = jObject.["attrs"].ToObject()

--- a/Serilog.Sinks.Scalyr.Tests/Json format.fs
+++ b/Serilog.Sinks.Scalyr.Tests/Json format.fs
@@ -18,7 +18,7 @@ let tests =
 
   testApi.Continue.WaitOne(1000) |> ignore
 
-  let actual = testApi.NewtonsoftReceived.[0] |> getFirstJEvent |> getJAttrs |> getObject "foo"
+  let actual = testApi.NewtonsoftReceived.[0] |> getFirstEvent |> getAttrs |> getObject "foo"
   
   let raw = testApi.Raw.[0]
 

--- a/Serilog.Sinks.Scalyr.Tests/Json format.fs
+++ b/Serilog.Sinks.Scalyr.Tests/Json format.fs
@@ -18,10 +18,12 @@ let tests =
 
   testApi.Continue.WaitOne(1000) |> ignore
 
-  let actual = testApi.Received.[0] |> getFirstEvent |> getAttrs |> getObject "foo"
+  let actual = testApi.NewtonsoftReceived.[0] |> getFirstJEvent |> getJAttrs |> getObject "foo"
+  
+  let raw = testApi.Raw.[0]
 
   let expected = JObject.Parse "{\"Foo\":\"Bar\"}"
 
   test "foo is set" {
-    Expect.isTrue (JToken.DeepEquals(actual, expected)) (sprintf "%O : %O" actual expected)
+    Expect.isTrue (JToken.DeepEquals(actual, expected)) $"{actual} : {expected} ({raw})"
   }

--- a/Serilog.Sinks.Scalyr.Tests/OutputTemplate.fs
+++ b/Serilog.Sinks.Scalyr.Tests/OutputTemplate.fs
@@ -18,5 +18,5 @@ let tests =
   let verboseLog = testApi.NewtonsoftReceived.[0]
 
   test "message attr is set" {
-    Expect.equal (verboseLog |> getFirstJEvent |> getJAttrs |> getJValue "message") "Verbose HELLO" "message attr"
+    Expect.equal (verboseLog |> getFirstEvent |> getAttrs |> getValue "message") "Verbose HELLO" "message attr"
   }

--- a/Serilog.Sinks.Scalyr.Tests/OutputTemplate.fs
+++ b/Serilog.Sinks.Scalyr.Tests/OutputTemplate.fs
@@ -15,8 +15,8 @@ let tests =
 
   testApi.Continue.WaitOne(1000) |> ignore
 
-  let verboseLog = testApi.Received.[0]
+  let verboseLog = testApi.NewtonsoftReceived.[0]
 
   test "message attr is set" {
-    Expect.equal (verboseLog |> getFirstEvent |> getAttrs |> getValue "message") "Verbose HELLO" "message attr"
+    Expect.equal (verboseLog |> getFirstJEvent |> getJAttrs |> getJValue "message") "Verbose HELLO" "message attr"
   }

--- a/Serilog.Sinks.Scalyr.Tests/Serilog.Sinks.Scalyr.Tests.fsproj
+++ b/Serilog.Sinks.Scalyr.Tests/Serilog.Sinks.Scalyr.Tests.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Helpers.fs" />

--- a/Serilog.Sinks.Scalyr.Tests/SystemText format.fs
+++ b/Serilog.Sinks.Scalyr.Tests/SystemText format.fs
@@ -1,0 +1,69 @@
+module SystemTextFormat
+
+open System.Text.Json
+open Expecto
+open Serilog
+open System
+open Newtonsoft.Json.Linq
+open Serilog.Sinks.Scalyr
+
+type Test = { Foo: string }
+
+[<Tests>]
+let tests =
+
+    use testApi = new TestApi()
+
+    let createLogger (engine : Engine) = 
+        LoggerConfiguration()
+            .MinimumLevel.Verbose()
+               .WriteTo.Scalyr(
+                "token",
+                "app",
+                Nullable 1,
+                TimeSpan.FromMilliseconds 100. |> Nullable,
+                scalyrUri = testApi.Scalyr.Uri,
+                engine = engine
+            )
+            .CreateLogger()
+            
+    let newtonsoftLogger = createLogger Engine.Newtonsoft
+            
+    let systemTextJsonLogger = createLogger Engine.SystemTextJson
+            
+    newtonsoftLogger.Error(exn "BOOM", "{@foo}", { Foo = "Bar" })
+    testApi.Continue.WaitOne(1000) |> ignore
+    
+    testApi.Continue.Reset |> ignore
+    systemTextJsonLogger.Error(exn "BOOM", "{@foo}", { Foo = "Bar" })
+    testApi.Continue.WaitOne(1000) |> ignore
+
+
+    let n_Received = testApi.NewtonsoftReceived.[0]
+    let n_foo = n_Received |> getFirstJEvent |> getJAttrs |> getObject "foo"
+    let n_ex = n_Received |> getFirstJEvent |> getJAttrs |> getObject "Exception"
+    
+    let s_Received = testApi.SystemTextJsonReceived.[0]
+    let s_foo = s_Received.RootElement |> getFirstEvent |> getAttrs |> getProperty "foo"
+    let s_ex = s_Received.RootElement |> getFirstEvent |> getAttrs |> getProperty "Exception"
+
+    let raw = testApi.Raw.[0]
+    
+    let n_expected_foo = "{\"Foo\":\"Bar\"}" |> JObject.Parse 
+    let n_expected_ex = exn "BOOM" |> JObject.FromObject
+    let s_expected_foo = "{\"Foo\":\"Bar\"}" |> JsonDocument.Parse 
+    let s_expected_ex = (exn "BOOM") |> JsonSerializer.SerializeToDocument
+    
+
+    testList "Information" [
+        
+        testCase "foo output is identical" <| fun _ -> Expect.equal (s_foo |> serializeElementIndented) (n_foo |> string) $"{n_foo} : {s_foo} ({raw})"
+        testCase "exn output is identical" <| fun _ -> Expect.equal (s_ex |> serializeElementIndented) (n_ex |> string) $"{n_ex} : {s_ex} ({raw})"
+        
+        testCase "foo result is identical" <| fun _ -> Expect.equal (s_expected_foo |> serializeDocumentIndented) (n_expected_foo |> string) $"{n_expected_foo} : {s_expected_foo} ({raw})"
+        testCase "exn result is identical" <| fun _ -> Expect.equal (s_expected_ex |> serializeDocumentIndented) (n_expected_ex |> string) $"{n_expected_ex} : {s_expected_ex} ({raw})"
+        
+        
+        testCase "received is identical" <| fun _ -> Expect.equal (s_Received |> serializeDocumentIndented ) (n_Received |> string) $"{n_Received} : {s_Received} ({raw})" 
+                                                                 
+    ]

--- a/Serilog.Sinks.Scalyr.Tests/SystemText format.fs
+++ b/Serilog.Sinks.Scalyr.Tests/SystemText format.fs
@@ -20,10 +20,10 @@ let tests =
                .WriteTo.Scalyr(
                 "token",
                 "app",
+                engine,
                 Nullable 1,
                 TimeSpan.FromMilliseconds 100. |> Nullable,
-                scalyrUri = testApi.Scalyr.Uri,
-                engine = engine
+                scalyrUri = testApi.Scalyr.Uri
             )
             .CreateLogger()
             

--- a/Serilog.Sinks.Scalyr.Tests/SystemText format.fs
+++ b/Serilog.Sinks.Scalyr.Tests/SystemText format.fs
@@ -65,7 +65,6 @@ let tests =
     systemTextJsonLogger.Error(exn "BOOM", "{@foo}", { Foo = "Bar" })
     testApi.Continue.WaitOne(1000) |> ignore
 
-
     let n_Received = testApi.NewtonsoftReceived.[0]
     let n_foo = n_Received |> getFirstEvent |> getAttrs |> getObject "foo"
     let n_ex = n_Received |> getFirstEvent |> getAttrs |> getObject "Exception"
@@ -80,17 +79,16 @@ let tests =
     let n_expected_ex = exn "BOOM" |> JObject.FromObject
     let s_expected_foo = "{\"Foo\":\"Bar\"}" |> JsonDocument.Parse 
     let s_expected_ex = (exn "BOOM") |> JsonSerializer.SerializeToDocument
-    
 
     testList "Information" [
         
         testCase "foo output is identical" <| fun _ -> Expect.equal (s_foo |> serializeElementIndented) (n_foo |> string) $"{n_foo} : {s_foo} ({raw})"
+        
         testCase "exn output is identical" <| fun _ -> Expect.equal (s_ex |> serializeElementIndented) (n_ex |> string) $"{n_ex} : {s_ex} ({raw})"
         
         testCase "foo result is identical" <| fun _ -> Expect.equal (s_expected_foo |> serializeDocumentIndented) (n_expected_foo |> string) $"{n_expected_foo} : {s_expected_foo} ({raw})"
+        
         testCase "exn result is identical" <| fun _ -> Expect.equal (s_expected_ex |> serializeDocumentIndented) (n_expected_ex |> string) $"{n_expected_ex} : {s_expected_ex} ({raw})"
         
-        
         testCase "received is identical" <| fun _ -> Expect.equal (s_Received |> serializeDocumentIndented ) (n_Received |> string) $"{n_Received} : {s_Received} ({raw})" 
-                                                                 
     ]

--- a/Serilog.Sinks.Scalyr.Tests/TestApi.fs
+++ b/Serilog.Sinks.Scalyr.Tests/TestApi.fs
@@ -2,6 +2,7 @@
 module TestApi
 
 open System
+open System.Text.Json
 open Newtonsoft.Json.Linq
 open System.Threading
 open Hornbill
@@ -16,11 +17,14 @@ type TestApi() =
     Response.withStatusCode 200 |> scalyr.AddResponse "/" Method.GET
     scalyr.Start() |> ignore
 
-  member __.Continue = autoResetEvent
+  member _.Continue = autoResetEvent
 
-  member __.Scalyr = scalyr
+  member _.Scalyr = scalyr
 
-  member __.Received with get() = scalyr.Requests |> Seq.map (fun r -> JObject.Parse r.Body) |> Seq.toArray
+  member _.NewtonsoftReceived with get() = scalyr.Requests |> Seq.map (fun r -> JObject.Parse r.Body) |> Seq.toArray
+  member _.SystemTextJsonReceived with get() = scalyr.Requests |> Seq.map (fun r -> JsonDocument.Parse r.Body) |> Seq.toArray
+  
+  member _.Raw with get() = scalyr.Requests |> Seq.map (fun r -> r.Body) |> Seq.toArray
 
   interface IDisposable with
-    member __.Dispose() = scalyr.Dispose()
+    member _.Dispose() = scalyr.Dispose()

--- a/Serilog.Sinks.Scalyr.Tests/Tests.fs
+++ b/Serilog.Sinks.Scalyr.Tests/Tests.fs
@@ -45,24 +45,24 @@ let tests =
 
   testList "Information" [
 
-    testCase "token is set" <| fun _ -> Expect.equal (verboseLog |> getJValue "token") "token" ""
+    testCase "token is set" <| fun _ -> Expect.equal (verboseLog |> getValue "token") "token" ""
 
-    testCase "session is a guid" <| fun _ -> Expect.isTrue (verboseLog |> getJValue "session" |> isGuid) ""
+    testCase "session is a guid" <| fun _ -> Expect.isTrue (verboseLog |> getValue "session" |> isGuid) ""
 
-    testCase "serverHost is set" <| fun _ -> Expect.equal (sessionInfo |> getJValue "serverHost") (Dns.GetHostName()) ""
+    testCase "serverHost is set" <| fun _ -> Expect.equal (sessionInfo |> getValue "serverHost") (Dns.GetHostName()) ""
 
-    testCase "logfile is set" <| fun _ -> Expect.equal (sessionInfo |> getJValue "logfile") "app" ""
+    testCase "logfile is set" <| fun _ -> Expect.equal (sessionInfo |> getValue "logfile") "app" ""
 
-    testCase "location is set from sessioninfo object" <| fun _ -> Expect.equal (sessionInfo |> getJValue "location") "Earth" ""
+    testCase "location is set from sessioninfo object" <| fun _ -> Expect.equal (sessionInfo |> getValue "location") "Earth" ""
 
     testCase "api received 6 logs" <| fun _ -> Expect.equal testApi.NewtonsoftReceived.Length 6 ""
 
-    testCase "events have incrementing ts" <| fun _ -> Expect.isTrue (testApi.NewtonsoftReceived |> Seq.map (getFirstJEvent >> getJValue "ts" >> int64) |> Seq.mapFold (fun state next -> next > state, next) startTs |> fst |> Seq.forall id) ""
+    testCase "events have incrementing ts" <| fun _ -> Expect.isTrue (testApi.NewtonsoftReceived |> Seq.map (getFirstEvent >> getValue "ts" >> int64) |> Seq.mapFold (fun state next -> next > state, next) startTs |> fst |> Seq.forall id) ""
 
-    testCase "events have incrementing sev" <| fun _ -> Expect.equal (testApi.NewtonsoftReceived |> Seq.map (getFirstJEvent >> getJValue "sev" >> int) |> Seq.toList) [ 1; 2; 3; 4; 5; 6 ] ""
+    testCase "events have incrementing sev" <| fun _ -> Expect.equal (testApi.NewtonsoftReceived |> Seq.map (getFirstEvent >> getValue "sev" >> int) |> Seq.toList) [ 1; 2; 3; 4; 5; 6 ] ""
 
-    testCase "message attr is set" <| fun _ -> Expect.equal (verboseLog |> getFirstJEvent |> getJAttrs |> getJValue "message") "Verbose \"bar\"" ""
+    testCase "message attr is set" <| fun _ -> Expect.equal (verboseLog |> getFirstEvent |> getAttrs |> getValue "message") "Verbose \"bar\"" ""
 
-    testCase "foo attr is set" <| fun _ -> Expect.equal (verboseLog |> getFirstJEvent |> getJAttrs |> getJValue "foo") "bar" ""
+    testCase "foo attr is set" <| fun _ -> Expect.equal (verboseLog |> getFirstEvent |> getAttrs |> getValue "foo") "bar" ""
     
   ]

--- a/Serilog.Sinks.Scalyr.Tests/Tests.fs
+++ b/Serilog.Sinks.Scalyr.Tests/Tests.fs
@@ -16,7 +16,7 @@ let tests =
   let startTs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() * 1000000L
 
   use testApi = new TestApi()
-
+  
   let logger =
     LoggerConfiguration()
         .MinimumLevel.Verbose()
@@ -42,7 +42,7 @@ let tests =
   let verboseLog = testApi.NewtonsoftReceived.[0]
   
   let sessionInfo = verboseLog.["sessionInfo"].ToObject()
-
+  
   testList "Information" [
 
     testCase "token is set" <| fun _ -> Expect.equal (verboseLog |> getValue "token") "token" ""
@@ -57,7 +57,7 @@ let tests =
 
     testCase "api received 6 logs" <| fun _ -> Expect.equal testApi.NewtonsoftReceived.Length 6 ""
 
-    testCase "events have incrementing ts" <| fun _ -> Expect.isTrue (testApi.NewtonsoftReceived |> Seq.map (getFirstEvent >> getValue "ts" >> int64) |> Seq.mapFold (fun state next -> next > state, next) startTs |> fst |> Seq.forall id) ""
+    testCase "events have incrementing ts" <| fun _ -> Expect.all (startTs :: (testApi.NewtonsoftReceived |> Seq.map (getFirstEvent >> getValue "ts" >> int64)|> Seq.toList)  |> Seq.pairwise) (fun pair -> fst pair < snd pair) ""
 
     testCase "events have incrementing sev" <| fun _ -> Expect.equal (testApi.NewtonsoftReceived |> Seq.map (getFirstEvent >> getValue "sev" >> int) |> Seq.toList) [ 1; 2; 3; 4; 5; 6 ] ""
 

--- a/Serilog.Sinks.Scalyr.Tests/Tests.fs
+++ b/Serilog.Sinks.Scalyr.Tests/Tests.fs
@@ -17,7 +17,18 @@ let tests =
 
   use testApi = new TestApi()
 
-  let logger = LoggerConfiguration().MinimumLevel.Verbose().WriteTo.Scalyr("token","app", Nullable 1, TimeSpan.FromMilliseconds 100. |> Nullable, scalyrUri = testApi.Scalyr.Uri, sessionInfo = { location = "Earth" }).CreateLogger()
+  let logger =
+    LoggerConfiguration()
+        .MinimumLevel.Verbose()
+        .WriteTo.Scalyr(
+            "token",
+            "app",
+            Nullable 1,
+            TimeSpan.FromMilliseconds 100. |> Nullable,
+            scalyrUri = testApi.Scalyr.Uri,
+            sessionInfo = { location = "Earth" }
+        )
+        .CreateLogger()
 
   logger.Verbose("Verbose {foo}", "bar")
   logger.Debug "Debug"
@@ -28,30 +39,30 @@ let tests =
 
   testApi.Continue.WaitOne(1000) |> ignore
 
-  let verboseLog = testApi.Received.[0]
-
+  let verboseLog = testApi.NewtonsoftReceived.[0]
+  
   let sessionInfo = verboseLog.["sessionInfo"].ToObject()
 
   testList "Information" [
 
-    testCase "token is set" <| fun _ -> Expect.equal (verboseLog |> getValue "token") "token" ""
+    testCase "token is set" <| fun _ -> Expect.equal (verboseLog |> getJValue "token") "token" ""
 
-    testCase "session is a guid" <| fun _ -> Expect.isTrue (verboseLog |> getValue "session" |> isGuid) ""
+    testCase "session is a guid" <| fun _ -> Expect.isTrue (verboseLog |> getJValue "session" |> isGuid) ""
 
-    testCase "serverHost is set" <| fun _ -> Expect.equal (sessionInfo |> getValue "serverHost") (Dns.GetHostName()) ""
+    testCase "serverHost is set" <| fun _ -> Expect.equal (sessionInfo |> getJValue "serverHost") (Dns.GetHostName()) ""
 
-    testCase "logfile is set" <| fun _ -> Expect.equal (sessionInfo |> getValue "logfile") "app" ""
+    testCase "logfile is set" <| fun _ -> Expect.equal (sessionInfo |> getJValue "logfile") "app" ""
 
-    testCase "location is set from sessioninfo object" <| fun _ -> Expect.equal (sessionInfo |> getValue "location") "Earth" ""
+    testCase "location is set from sessioninfo object" <| fun _ -> Expect.equal (sessionInfo |> getJValue "location") "Earth" ""
 
-    testCase "api received 6 logs" <| fun _ -> Expect.equal testApi.Received.Length 6 ""
+    testCase "api received 6 logs" <| fun _ -> Expect.equal testApi.NewtonsoftReceived.Length 6 ""
 
-    testCase "events have incrementing ts" <| fun _ -> Expect.isTrue (testApi.Received |> Seq.map (getFirstEvent >> getValue "ts" >> int64) |> Seq.mapFold (fun state next -> next > state, next) startTs |> fst |> Seq.forall id) ""
+    testCase "events have incrementing ts" <| fun _ -> Expect.isTrue (testApi.NewtonsoftReceived |> Seq.map (getFirstJEvent >> getJValue "ts" >> int64) |> Seq.mapFold (fun state next -> next > state, next) startTs |> fst |> Seq.forall id) ""
 
-    testCase "events have incrementing sev" <| fun _ -> Expect.equal (testApi.Received |> Seq.map (getFirstEvent >> getValue "sev" >> int) |> Seq.toList) [ 1; 2; 3; 4; 5; 6 ] ""
+    testCase "events have incrementing sev" <| fun _ -> Expect.equal (testApi.NewtonsoftReceived |> Seq.map (getFirstJEvent >> getJValue "sev" >> int) |> Seq.toList) [ 1; 2; 3; 4; 5; 6 ] ""
 
-    testCase "message attr is set" <| fun _ -> Expect.equal (verboseLog |> getFirstEvent |> getAttrs |> getValue "message") "Verbose \"bar\"" ""
+    testCase "message attr is set" <| fun _ -> Expect.equal (verboseLog |> getFirstJEvent |> getJAttrs |> getJValue "message") "Verbose \"bar\"" ""
 
-    testCase "foo attr is set" <| fun _ -> Expect.equal (verboseLog |> getFirstEvent |> getAttrs |> getValue "foo") "bar" ""
-
+    testCase "foo attr is set" <| fun _ -> Expect.equal (verboseLog |> getFirstJEvent |> getJAttrs |> getJValue "foo") "bar" ""
+    
   ]

--- a/Serilog.Sinks.Scalyr/Engine.cs
+++ b/Serilog.Sinks.Scalyr/Engine.cs
@@ -1,8 +1,18 @@
 namespace Serilog.Sinks.Scalyr
 {
+  /// <summary>
+  /// Type of serialization method to use when writing log events to Scalyr.
+  /// </summary>
   public enum Engine
   {
+    /// <summary>
+    /// Use Newtonsoft.Json to serialize log events.
+    /// </summary>
     Newtonsoft,
+
+    /// <summary>
+    /// Use System.Text.Json to serialize log events.
+    /// </summary>
     SystemTextJson
   }
 }

--- a/Serilog.Sinks.Scalyr/Engine.cs
+++ b/Serilog.Sinks.Scalyr/Engine.cs
@@ -1,0 +1,8 @@
+namespace Serilog.Sinks.Scalyr
+{
+  public enum Engine
+  {
+    Newtonsoft,
+    SystemTextJson
+  }
+}

--- a/Serilog.Sinks.Scalyr/IScalyrFormatter.cs
+++ b/Serilog.Sinks.Scalyr/IScalyrFormatter.cs
@@ -3,9 +3,24 @@ using Serilog.Events;
 
 namespace Serilog.Sinks.Scalyr
 {
-    internal interface IScalyrFormatter
-    {
-        ScalyrEvent MapToScalyrEvent(LogEvent logEvent, int index);
-        string Format(IEnumerable<LogEvent> events);
-    }
+  /// <summary>
+  /// Converts Serilog <see cref="LogEvent"/>s to <see cref="ScalyrEvent"/>s.
+  /// </summary>
+  internal interface IScalyrFormatter
+  {
+    /// <summary>
+    /// Convert a Serilog <see cref="LogEvent"/> to a <see cref="ScalyrEvent"/>.
+    /// </summary>
+    /// <param name="logEvent">Serilog log event to convert.</param>
+    /// <param name="index">Relative index of <paramref name="logEvent"/> used to generate a timestamp.</param>
+    /// <returns>Converted <see cref="ScalyrEvent"/>.</returns>
+    ScalyrEvent MapToScalyrEvent(LogEvent logEvent, int index);
+
+    /// <summary>
+    /// Serializes a sequence of Serilog <see cref="LogEvent"/>s.
+    /// </summary>
+    /// <param name="events">Sequence of log events to serialize.</param>
+    /// <returns>Serialized form of <paramref name="events"/></returns>
+    string Format(IEnumerable<LogEvent> events);
+  }
 }

--- a/Serilog.Sinks.Scalyr/IScalyrFormatter.cs
+++ b/Serilog.Sinks.Scalyr/IScalyrFormatter.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using Serilog.Events;
+
+namespace Serilog.Sinks.Scalyr
+{
+    internal interface IScalyrFormatter
+    {
+        ScalyrEvent MapToScalyrEvent(LogEvent logEvent, int index);
+        string Format(IEnumerable<LogEvent> events);
+    }
+}

--- a/Serilog.Sinks.Scalyr/LoggerConfigurationSerilogExtensions.cs
+++ b/Serilog.Sinks.Scalyr/LoggerConfigurationSerilogExtensions.cs
@@ -74,18 +74,17 @@ namespace Serilog
       string outputTemplate = null,
       LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum)
     {
-      var messageTemplateTextFormatter = String.IsNullOrWhiteSpace(outputTemplate) ? null : new MessageTemplateTextFormatter(outputTemplate, null);
+      var messageTemplateTextFormatter = string.IsNullOrWhiteSpace(outputTemplate) ? null : new MessageTemplateTextFormatter(outputTemplate, null);
       IScalyrFormatter scalyrFormatter = engine switch
       {
         Engine.SystemTextJson => new SystemTextJsonScalyrFormatter(token, logfile, sessionInfo, messageTemplateTextFormatter),
         _ => new NewtonsoftScalyrFormatter(token, logfile, sessionInfo, messageTemplateTextFormatter),
       };
       var sink =
-        queueLimit.HasValue ? 
-          new ScalyrSink(scalyrFormatter, scalyrUri, batchSizeLimit ?? ScalyrSink.DefaultBatchPostingLimit, period ?? ScalyrSink.DefaultPeriod, queueLimit.Value) 
+        queueLimit.HasValue
+          ? new ScalyrSink(scalyrFormatter, scalyrUri, batchSizeLimit ?? ScalyrSink.DefaultBatchPostingLimit, period ?? ScalyrSink.DefaultPeriod, queueLimit.Value)
           : new ScalyrSink(scalyrFormatter, scalyrUri, batchSizeLimit ?? ScalyrSink.DefaultBatchPostingLimit, period ?? ScalyrSink.DefaultPeriod);
       return loggerSinkConfiguration.Sink(sink, restrictedToMinimumLevel: restrictedToMinimumLevel);
     }
-
   }
 }

--- a/Serilog.Sinks.Scalyr/LoggerConfigurationSerilogExtensions.cs
+++ b/Serilog.Sinks.Scalyr/LoggerConfigurationSerilogExtensions.cs
@@ -24,7 +24,6 @@ namespace Serilog
     /// <param name="scalyrUri">The base URI for Scalyr. Defaults to https://scalyr.com.</param>
     /// <param name="outputTemplate">A message template describing the output messages.See https://github.com/serilog/serilog/wiki/Formatting-Output.</param>
     /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
-    /// <param name="engine">The formatting engine to use when serializing the log events. Defaults to Newtonsoft.Json</param>
     public static LoggerConfiguration Scalyr(
       this LoggerSinkConfiguration loggerSinkConfiguration,
       string token,
@@ -35,8 +34,45 @@ namespace Serilog
       object sessionInfo = null,
       Uri scalyrUri = null,
       string outputTemplate = null,
-      LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
-      Engine engine = Engine.Newtonsoft)
+      LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum) =>
+      Scalyr(loggerSinkConfiguration,
+        token,
+        logfile,
+        Engine.Newtonsoft,
+        batchSizeLimit,
+        period,
+        queueLimit,
+        sessionInfo,
+        scalyrUri,
+        outputTemplate,
+        restrictedToMinimumLevel);
+
+    /// <summary>
+    /// Adds a sink that writes log events to <a href="https://scalyr.com">Scalyr</a>.
+    /// </summary>
+    /// <param name="loggerSinkConfiguration">The logger configuration.</param>
+    /// <param name="token">"Write Logs" API token. Find API tokens at https://www.scalyr.com/keys.</param>
+    /// <param name="logfile">The name of the log file being written to.</param>
+    /// <param name="batchSizeLimit">The maximum number of events to include in a single batch.</param>
+    /// <param name="period">The time to wait between checking for event batches.</param>
+    /// <param name="queueLimit">Maximum number of events in the queue.</param>
+    /// <param name="sessionInfo">Additional information about the session. See https://www.scalyr.com/help/api.</param>
+    /// <param name="scalyrUri">The base URI for Scalyr. Defaults to https://scalyr.com.</param>
+    /// <param name="outputTemplate">A message template describing the output messages.See https://github.com/serilog/serilog/wiki/Formatting-Output.</param>
+    /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
+    /// <param name="engine">The formatting engine to use when serializing the log events. Defaults to Newtonsoft.Json</param>
+    public static LoggerConfiguration Scalyr(
+      this LoggerSinkConfiguration loggerSinkConfiguration,
+      string token,
+      string logfile,
+      Engine engine,
+      int? batchSizeLimit = null,
+      TimeSpan? period = null,
+      int? queueLimit = null,
+      object sessionInfo = null,
+      Uri scalyrUri = null,
+      string outputTemplate = null,
+      LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum)
     {
       var messageTemplateTextFormatter = String.IsNullOrWhiteSpace(outputTemplate) ? null : new MessageTemplateTextFormatter(outputTemplate, null);
       IScalyrFormatter scalyrFormatter = engine switch

--- a/Serilog.Sinks.Scalyr/NewtonsoftScalyrFormatter.cs
+++ b/Serilog.Sinks.Scalyr/NewtonsoftScalyrFormatter.cs
@@ -62,10 +62,12 @@ namespace Serilog.Sinks.Scalyr
           attrs.Add(property.Key, JToken.Parse(json.ToString()));
         }
       }
+
       if (logEvent.Exception != null)
       {
         attrs.Add("Exception", JObject.FromObject(logEvent.Exception));
       }
+
       using (var stringWriter = new StringWriter())
       {
         if (_messageTemplateTextFormatter != null)
@@ -76,6 +78,7 @@ namespace Serilog.Sinks.Scalyr
         {
           stringWriter.Write(logEvent.RenderMessage());
         }
+
         attrs.Add("message", stringWriter.ToString());
       }
       var ts = logEvent.Timestamp.ToUnixTimeMilliseconds() * 1000000 + index;

--- a/Serilog.Sinks.Scalyr/NewtonsoftScalyrFormatter.cs
+++ b/Serilog.Sinks.Scalyr/NewtonsoftScalyrFormatter.cs
@@ -12,7 +12,7 @@ using System.Net;
 
 namespace Serilog.Sinks.Scalyr
 {
-  class NewtonsoftScalyrFormatter : IScalyrFormatter
+  internal class NewtonsoftScalyrFormatter : IScalyrFormatter
   {
     private readonly ScalyrSession _session;
     private readonly JsonSerializerSettings _jsonSerializerSettings;

--- a/Serilog.Sinks.Scalyr/NewtonsoftScalyrFormatter.cs
+++ b/Serilog.Sinks.Scalyr/NewtonsoftScalyrFormatter.cs
@@ -12,15 +12,15 @@ using System.Net;
 
 namespace Serilog.Sinks.Scalyr
 {
-  class ScalyrFormatter
+  class NewtonsoftScalyrFormatter : IScalyrFormatter
   {
-    readonly ScalyrSession _session;
-    readonly JsonSerializerSettings _jsonSerializerSettings;
-    readonly JsonValueFormatter jsonValueFormatter = new JsonValueFormatter(null);
-    readonly MessageTemplateTextFormatter _messageTemplateTextFormatter;
-    long lastTimeStamp;
+    private readonly ScalyrSession _session;
+    private readonly JsonSerializerSettings _jsonSerializerSettings;
+    private readonly JsonValueFormatter _jsonValueFormatter = new JsonValueFormatter(null);
+    private readonly MessageTemplateTextFormatter _messageTemplateTextFormatter;
+    private long _lastTimeStamp;
 
-    public ScalyrFormatter(string token, string logfile, object sessionInfo, MessageTemplateTextFormatter messageTemplateTextFormatter)
+    public NewtonsoftScalyrFormatter(string token, string logfile, object sessionInfo, MessageTemplateTextFormatter messageTemplateTextFormatter)
     {
       _jsonSerializerSettings = new JsonSerializerSettings
       {
@@ -31,9 +31,11 @@ namespace Serilog.Sinks.Scalyr
         }
       };
       _messageTemplateTextFormatter = messageTemplateTextFormatter;
-      _session = new ScalyrSession { Token = token, Session = Guid.NewGuid().ToString("N"), SessionInfo = JObject.FromObject(sessionInfo ?? new object()) };
-      _session.SessionInfo.Add("serverHost", getHostName());
-      _session.SessionInfo.Add("logfile", logfile);
+      _session = new ScalyrSession { Token = token, Session = Guid.NewGuid().ToString("N") };
+      var sessionObject = JObject.FromObject(sessionInfo ?? new object()) ;
+      sessionObject.Add("serverHost", getHostName());
+      sessionObject.Add("logfile", logfile);
+      _session.SessionInfo = sessionObject;
     }
 
     string getHostName()
@@ -48,14 +50,14 @@ namespace Serilog.Sinks.Scalyr
       }
     }
 
-    ScalyrEvent MapToScalyrEvent(LogEvent logEvent, int index)
+    public ScalyrEvent MapToScalyrEvent(LogEvent logEvent, int index)
     {
       var attrs = new JObject();
       foreach (var property in logEvent.Properties)
       {
         using (var json = new StringWriter())
         {
-          jsonValueFormatter.Format(property.Value, json);
+          _jsonValueFormatter.Format(property.Value, json);
           attrs.Add(property.Key, JToken.Parse(json.ToString()));
         }
       }
@@ -76,8 +78,8 @@ namespace Serilog.Sinks.Scalyr
         attrs.Add("message", stringWriter.ToString());
       }
       var ts = logEvent.Timestamp.ToUnixTimeMilliseconds() * 1000000 + index;
-      while (ts <= lastTimeStamp) { ts++; }
-      lastTimeStamp = ts;
+      while (ts <= _lastTimeStamp) { ts++; }
+      _lastTimeStamp = ts;
       return new ScalyrEvent
       {
         Ts = ts.ToString(),

--- a/Serilog.Sinks.Scalyr/NewtonsoftScalyrFormatter.cs
+++ b/Serilog.Sinks.Scalyr/NewtonsoftScalyrFormatter.cs
@@ -81,12 +81,12 @@ namespace Serilog.Sinks.Scalyr
 
         attrs.Add("message", stringWriter.ToString());
       }
-      var ts = logEvent.Timestamp.ToUnixTimeMilliseconds() * 1000000 + index;
-      while (ts <= _lastTimeStamp) { ts++; }
-      _lastTimeStamp = ts;
+
+      _lastTimeStamp = Math.Max(_lastTimeStamp + 1, logEvent.Timestamp.ToUnixTimeMilliseconds() * 1000000 + index);
+
       return new ScalyrEvent
       {
-        Ts = ts.ToString(),
+        Ts = _lastTimeStamp.ToString(),
         Sev = ((int)logEvent.Level) + 1,
         Attrs = attrs
       };

--- a/Serilog.Sinks.Scalyr/NewtonsoftScalyrFormatter.cs
+++ b/Serilog.Sinks.Scalyr/NewtonsoftScalyrFormatter.cs
@@ -32,7 +32,8 @@ namespace Serilog.Sinks.Scalyr
       };
       _messageTemplateTextFormatter = messageTemplateTextFormatter;
       _session = new ScalyrSession { Token = token, Session = Guid.NewGuid().ToString("N") };
-      var sessionObject = JObject.FromObject(sessionInfo ?? new object()) ;
+      JObject sessionObject = JObject.FromObject(sessionInfo ?? new object())
+                              ?? throw new InvalidOperationException("Could not serialize session info");
       sessionObject.Add("serverHost", getHostName());
       sessionObject.Add("logfile", logfile);
       _session.SessionInfo = sessionObject;

--- a/Serilog.Sinks.Scalyr/ScalyrEvent.cs
+++ b/Serilog.Sinks.Scalyr/ScalyrEvent.cs
@@ -1,11 +1,9 @@
-using Newtonsoft.Json.Linq;
-
 namespace Serilog.Sinks.Scalyr
 {
-  class ScalyrEvent
+  internal class ScalyrEvent
   {
     public string Ts { get; set; }
     public int Sev { get; set; }
-    public JObject Attrs { get; set; }
+    public object Attrs { get; set; }
   }
 }

--- a/Serilog.Sinks.Scalyr/ScalyrSession.cs
+++ b/Serilog.Sinks.Scalyr/ScalyrSession.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using Newtonsoft.Json.Linq;
 
 namespace Serilog.Sinks.Scalyr
 {
@@ -8,6 +7,6 @@ namespace Serilog.Sinks.Scalyr
     public string Token { get; set; }
     public string Session { get; set; }
     public IEnumerable<ScalyrEvent> Events { get; set; }
-    public JObject SessionInfo { get; set; }
+    public object SessionInfo { get; set; }
   }
 }

--- a/Serilog.Sinks.Scalyr/ScalyrSession.cs
+++ b/Serilog.Sinks.Scalyr/ScalyrSession.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace Serilog.Sinks.Scalyr
 {
-  class ScalyrSession
+  internal class ScalyrSession
   {
     public string Token { get; set; }
     public string Session { get; set; }

--- a/Serilog.Sinks.Scalyr/ScalyrSink.cs
+++ b/Serilog.Sinks.Scalyr/ScalyrSink.cs
@@ -7,7 +7,7 @@ using System.Net.Http;
 
 namespace Serilog.Sinks.Scalyr
 {
-  class ScalyrSink : PeriodicBatchingSink
+  internal class ScalyrSink : PeriodicBatchingSink
   {
     readonly IScalyrFormatter _scalyrFormatter;
     readonly Uri _scalyrUri = new Uri("https://www.scalyr.com");

--- a/Serilog.Sinks.Scalyr/ScalyrSink.cs
+++ b/Serilog.Sinks.Scalyr/ScalyrSink.cs
@@ -9,19 +9,19 @@ namespace Serilog.Sinks.Scalyr
 {
   class ScalyrSink : PeriodicBatchingSink
   {
-    readonly ScalyrFormatter _scalyrFormatter;
+    readonly IScalyrFormatter _scalyrFormatter;
     readonly Uri _scalyrUri = new Uri("https://www.scalyr.com");
     static readonly HttpClient _httpClient = new HttpClient();
     public const int DefaultBatchPostingLimit = 10;
     public static readonly TimeSpan DefaultPeriod = TimeSpan.FromSeconds(5);
 
-    public ScalyrSink(ScalyrFormatter scalyrFormatter, Uri scalyrUri, int batchSizeLimit, TimeSpan period) : base(batchSizeLimit, period)
+    public ScalyrSink(IScalyrFormatter scalyrFormatter, Uri scalyrUri, int batchSizeLimit, TimeSpan period) : base(batchSizeLimit, period)
     {
       _scalyrFormatter = scalyrFormatter;
       _scalyrUri = new Uri(scalyrUri ?? _scalyrUri, "addEvents");
     }
 
-    public ScalyrSink(ScalyrFormatter scalyrFormatter, Uri scalyrUri, int batchSizeLimit, TimeSpan period, int queueLimit) : base(batchSizeLimit, period, queueLimit)
+    public ScalyrSink(IScalyrFormatter scalyrFormatter, Uri scalyrUri, int batchSizeLimit, TimeSpan period, int queueLimit) : base(batchSizeLimit, period, queueLimit)
     {
       _scalyrFormatter = scalyrFormatter;
       _scalyrUri = new Uri(scalyrUri ?? _scalyrUri, "addEvents");

--- a/Serilog.Sinks.Scalyr/Serilog.Sinks.Scalyr.csproj
+++ b/Serilog.Sinks.Scalyr/Serilog.Sinks.Scalyr.csproj
@@ -13,10 +13,12 @@
     <PackageIcon>logo.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
+    <LangVersion>default</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.1.0" />
+    <PackageReference Include="System.Text.Json" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\LICENSE" Pack="true" PackagePath="" />

--- a/Serilog.Sinks.Scalyr/SystemTextJsonScalyrFormatter.cs
+++ b/Serilog.Sinks.Scalyr/SystemTextJsonScalyrFormatter.cs
@@ -30,7 +30,7 @@ namespace Serilog.Sinks.Scalyr
       };
       _messageTemplateTextFormatter = messageTemplateTextFormatter;
       _session = new ScalyrSession { Token = token, Session = Guid.NewGuid().ToString("N") };
-      JsonNode? sessionObject = JsonSerializer.SerializeToNode(sessionInfo ?? new object(), _jsonSerializerSettings);
+      JsonNode sessionObject = JsonSerializer.SerializeToNode(sessionInfo ?? new object(), _jsonSerializerSettings);
       sessionObject["serverHost"] = JsonValue.Create(GetHostName());
       sessionObject["logfile"] = JsonValue.Create(logfile);
       _session.SessionInfo = sessionObject;

--- a/Serilog.Sinks.Scalyr/SystemTextJsonScalyrFormatter.cs
+++ b/Serilog.Sinks.Scalyr/SystemTextJsonScalyrFormatter.cs
@@ -69,16 +69,11 @@ namespace Serilog.Sinks.Scalyr
         attrs.Add("message", stringWriter.ToString());
       }
 
-      long ts = logEvent.Timestamp.ToUnixTimeMilliseconds() * 1000000 + index;
-      while (ts <= _lastTimeStamp)
-      {
-        ts++;
-      }
+      _lastTimeStamp = Math.Max(_lastTimeStamp + 1, logEvent.Timestamp.ToUnixTimeMilliseconds() * 1000000 + index);
 
-      _lastTimeStamp = ts;
       return new ScalyrEvent
       {
-        Ts = ts.ToString(),
+        Ts = _lastTimeStamp.ToString(),
         Sev = (int)logEvent.Level + 1,
         Attrs = attrs
       };

--- a/Serilog.Sinks.Scalyr/SystemTextJsonScalyrFormatter.cs
+++ b/Serilog.Sinks.Scalyr/SystemTextJsonScalyrFormatter.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using Serilog.Events;
+using Serilog.Formatting.Display;
+using Serilog.Formatting.Json;
+
+namespace Serilog.Sinks.Scalyr
+{
+  internal class SystemTextJsonScalyrFormatter : IScalyrFormatter
+  {
+    private readonly JsonSerializerOptions _jsonSerializerSettings;
+    private readonly JsonValueFormatter _jsonValueFormatter = new JsonValueFormatter(null);
+    private readonly MessageTemplateTextFormatter _messageTemplateTextFormatter;
+    private readonly ScalyrSession _session;
+    private long _lastTimeStamp;
+
+
+    public SystemTextJsonScalyrFormatter(string token, string logfile, object sessionInfo, MessageTemplateTextFormatter messageTemplateTextFormatter)
+    {
+      _jsonSerializerSettings = new JsonSerializerOptions
+      {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+      };
+      _messageTemplateTextFormatter = messageTemplateTextFormatter;
+      _session = new ScalyrSession { Token = token, Session = Guid.NewGuid().ToString("N") };
+      JsonNode? sessionObject = JsonSerializer.SerializeToNode(sessionInfo ?? new object(), _jsonSerializerSettings);
+      sessionObject["serverHost"] = JsonValue.Create(GetHostName());
+      sessionObject["logfile"] = JsonValue.Create(logfile);
+      _session.SessionInfo = sessionObject;
+    }
+
+    /// <inheritdoc />
+    public ScalyrEvent MapToScalyrEvent(LogEvent logEvent, int index) // var attrs_ = new JsonObject();
+    {
+      var attrs = new JsonObject();
+      foreach (KeyValuePair<string, LogEventPropertyValue> property in logEvent.Properties)
+      {
+        using (var json = new StringWriter())
+        {
+          _jsonValueFormatter.Format(property.Value, json);
+          attrs.Add(property.Key, JsonNode.Parse(json.ToString()));
+        }
+      }
+
+      if (logEvent.Exception != null)
+      {
+        attrs.Add("Exception", JsonSerializer.Serialize(logEvent.Exception, _jsonSerializerSettings));
+      }
+
+      using (var stringWriter = new StringWriter())
+      {
+        if (_messageTemplateTextFormatter != null)
+        {
+          _messageTemplateTextFormatter.Format(logEvent, stringWriter);
+        }
+        else
+        {
+          stringWriter.Write(logEvent.RenderMessage());
+        }
+
+        attrs.Add("message", stringWriter.ToString());
+      }
+
+      long ts = logEvent.Timestamp.ToUnixTimeMilliseconds() * 1000000 + index;
+      while (ts <= _lastTimeStamp)
+      {
+        ts++;
+      }
+
+      _lastTimeStamp = ts;
+      return new ScalyrEvent
+      {
+        Ts = ts.ToString(),
+        Sev = (int)logEvent.Level + 1,
+        Attrs = attrs
+      };
+    }
+
+    public string Format(IEnumerable<LogEvent> events)
+    {
+      _session.Events = events.Select(MapToScalyrEvent);
+      string json = JsonSerializer.Serialize(_session, _jsonSerializerSettings);
+      return json;
+    }
+
+    private static string GetHostName()
+    {
+      try
+      {
+        return Dns.GetHostName();
+      }
+      catch
+      {
+        return new[] { "COMPUTERNAME", "HOSTNAME" }.Select(Environment.GetEnvironmentVariable).FirstOrDefault() ?? "SERVERHOST";
+      }
+    }
+  }
+}

--- a/Serilog.Sinks.Scalyr/SystemTextJsonScalyrFormatter.cs
+++ b/Serilog.Sinks.Scalyr/SystemTextJsonScalyrFormatter.cs
@@ -30,7 +30,8 @@ namespace Serilog.Sinks.Scalyr
       };
       _messageTemplateTextFormatter = messageTemplateTextFormatter;
       _session = new ScalyrSession { Token = token, Session = Guid.NewGuid().ToString("N") };
-      JsonNode sessionObject = JsonSerializer.SerializeToNode(sessionInfo ?? new object(), _jsonSerializerSettings);
+      JsonNode sessionObject = JsonSerializer.SerializeToNode(sessionInfo ?? new object(), _jsonSerializerSettings)
+                               ?? throw new InvalidOperationException("Could not serialize session info");
       sessionObject["serverHost"] = JsonValue.Create(GetHostName());
       sessionObject["logfile"] = JsonValue.Create(logfile);
       _session.SessionInfo = sessionObject;


### PR DESCRIPTION
In order to increase the performance of serializing logs when writing to Scalyr, I added the option to use the `System.Text.Json` serializer instead of `Newtonsoft.Json` through the use of the `Serilog.Sinks.Scalyr.Engine` enum.

# Notes

For these points, if any are a problem, just let me know and I can revert them.

- Updated some of the tests to some more modern patterns.
- Formatted a lot of the code according to the style I was seeing.
- Explicitly set visibility of classes to `internal` where they were implicit before.
- Changed the timestamp test case to check that they are strictly increasing.