### PR TITLE
Serilog error about duplicate "message" property can lead to OutOfMemory exceptions

### DIFF
--- a/Serilog.Sinks.Scalyr/KeyValuePairExtensions.cs
+++ b/Serilog.Sinks.Scalyr/KeyValuePairExtensions.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.Generic;
+
+namespace Serilog.Sinks.Scalyr;
+
+/// <summary>
+/// Extension methods for <see cref="KeyValuePair{TKey,TValue}"/>.
+/// </summary>
+public static class KeyValuePairExtensions
+{
+    /// <summary>
+    /// Deconstructs the key value pair into a key and value.
+    /// </summary>
+    /// <param name="kvp">The key value pair.</param>
+    /// <param name="key">The key.</param>
+    /// <param name="value">The value.</param>
+    /// <typeparam name="TK">The type of the key.</typeparam>
+    /// <typeparam name="TV">The type of the value.</typeparam>
+    public static void Deconstruct<TK, TV>(this KeyValuePair<TK, TV> kvp, out TK key, out TV value)
+    {
+        key = kvp.Key;
+        value = kvp.Value;
+    }
+}

--- a/Serilog.Sinks.Scalyr/KeyValuePairExtensions.cs
+++ b/Serilog.Sinks.Scalyr/KeyValuePairExtensions.cs
@@ -3,7 +3,7 @@
 namespace Serilog.Sinks.Scalyr;
 
 /// <summary>
-/// Extension methods for <see cref="KeyValuePair{TKey,TValue}"/>.
+///     Extension methods for <see cref="KeyValuePair{TKey,TValue}"/>.
 /// </summary>
 public static class KeyValuePairExtensions
 {

--- a/Serilog.Sinks.Scalyr/NewtonsoftScalyrFormatter.cs
+++ b/Serilog.Sinks.Scalyr/NewtonsoftScalyrFormatter.cs
@@ -35,8 +35,8 @@ class NewtonsoftScalyrFormatter : IScalyrFormatter
         _session = new ScalyrSession { Token = token, Session = Guid.NewGuid().ToString("N") };
         var sessionObject = JObject.FromObject(sessionInfo ?? new object())
                             ?? throw new InvalidOperationException("Could not serialize session info");
-        sessionObject.Add("serverHost", getHostName());
-        sessionObject.Add("logfile", logfile);
+        sessionObject["serverHost"] = getHostName();
+        sessionObject["logfile"] = logfile;
         _session.SessionInfo = sessionObject;
     }
 
@@ -47,10 +47,10 @@ class NewtonsoftScalyrFormatter : IScalyrFormatter
             using (var json = new StringWriter())
             {
                 _jsonValueFormatter.Format(property.Value, json);
-                attrs.Add(property.Key, JToken.Parse(json.ToString()));
+                attrs[property.Key] = JToken.Parse(json.ToString());
             }
 
-        if (logEvent.Exception != null) attrs.Add("Exception", JObject.FromObject(logEvent.Exception));
+        if (logEvent.Exception != null) attrs["Exception"] = JObject.FromObject(logEvent.Exception);
 
         using (var stringWriter = new StringWriter())
         {
@@ -59,7 +59,7 @@ class NewtonsoftScalyrFormatter : IScalyrFormatter
             else
                 stringWriter.Write(logEvent.RenderMessage());
 
-            attrs.Add("message", stringWriter.ToString());
+            attrs["message"] = stringWriter.ToString();
         }
 
         _lastTimeStamp = Math.Max(_lastTimeStamp + 1, logEvent.Timestamp.ToUnixTimeMilliseconds() * 1000000 + index);


### PR DESCRIPTION
The current implementation of the formatters uses the `IDictionary.Add()` method to include message properties into the event object payload. If the log entry already contains "message" or "Exception", this will cause an exception:
``` cs
System.ArgumentException: An item with the same key has already been added. Key: {0} (Parameter 'message')
```

This PR changes behavior to use the indexer `set` method instead to overwrite any existing properties by that key.